### PR TITLE
Fix rule context variance

### DIFF
--- a/dialector-kt/src/main/kotlin/dev/dialector/diagnostic/DiagnosticRule.kt
+++ b/dialector-kt/src/main/kotlin/dev/dialector/diagnostic/DiagnosticRule.kt
@@ -11,10 +11,10 @@ public interface DiagnosticContext {
 }
 
 /**
- * A rule that defines [ModelDiagnostics] that should be produced for nodes matching a [NodePredicate]
+ * A rule that produces diagnostics for nodes matching a [NodePredicate]
  */
 public interface DiagnosticRule<T : Node, C : DiagnosticContext> {
-    public val isValidFor: NodePredicate<T, in C>
+    public val isValidFor: NodePredicate<T, C>
     public val diagnostics: C.(node: T) -> Unit
 
     public operator fun invoke(node: Node, context: C) {
@@ -29,10 +29,10 @@ public interface DiagnosticRule<T : Node, C : DiagnosticContext> {
  * @param T The node type being checked.
  * @param C The [DiagnosticContext] type
  */
-public infix fun <T : Node, C : DiagnosticContext> NodePredicate<T, in C>.check(
+public infix fun <T : Node, C : DiagnosticContext> NodePredicate<T, C>.check(
     check: C.(node: T) -> Unit,
 ): DiagnosticRule<T, C> =
     object : DiagnosticRule<T, C> {
-        override val isValidFor: NodePredicate<T, in C> = this@check
+        override val isValidFor: NodePredicate<T, C> = this@check
         override val diagnostics: C.(node: T) -> Unit = check
     }

--- a/dialector-kt/src/main/kotlin/dev/dialector/semantic/type/TypePredicate.kt
+++ b/dialector-kt/src/main/kotlin/dev/dialector/semantic/type/TypePredicate.kt
@@ -9,25 +9,25 @@ import kotlin.reflect.KClass
 /**
  * A clause that describes a type.
  */
-public interface TypePredicate<T : Type, C> : TypesafePredicate<T, C>
+public interface TypePredicate<T : Type, in C> : TypesafePredicate<T, C>
 
 /**
  * A special TypeClause that matches against a specific Type.
  *
  * This specialization facilitates optimizations in TypeLattice implementation.
  */
-public class TypeObjectPredicate<T : Type, C>(type: T) : TypePredicate<T, C>, InstancePredicate<T, C>(type)
+public class TypeObjectPredicate<T : Type>(type: T) : TypePredicate<T, Any>, InstancePredicate<T>(type)
 
 /**
  * A special TypeClause that matches against a specific Typeclass
  *
  * This specialization facilitates optimizations in TypeLattice implementation.
  */
-public class TypeClassPredicate<T : Type, C>(
+public class TypeClassPredicate<T : Type>(
     typeClass: KClass<T>,
-) : TypePredicate<T, C>, ClassifierPredicate<T, C>(typeClass)
+) : TypePredicate<T, Any>, ClassifierPredicate<T>(typeClass)
 
-public class TypeLogicalPredicate<T : Type, C>(
+public class TypeLogicalPredicate<T : Type, in C>(
     typeClass: KClass<T>,
     predicate: C.(T) -> Boolean,
 ) : TypePredicate<T, C>, LogicalPredicate<T, C>(typeClass, predicate)

--- a/dialector-kt/src/main/kotlin/dev/dialector/semantic/type/lattice/StandardTypeLattice.kt
+++ b/dialector-kt/src/main/kotlin/dev/dialector/semantic/type/lattice/StandardTypeLattice.kt
@@ -12,13 +12,13 @@ public data class AndType(val members: Set<Type>) : Type
 public data class OrType(val members: Set<Type>) : Type
 
 public class StandardTypeLattice<C>(
-    supertypeRelations: Collection<SupertypeRelation<*, in C>>,
-    subtypeRules: Collection<SupertypeRule<in C>>,
+    supertypeRelations: Collection<SupertypeRelation<*, C>>,
+    subtypeRules: Collection<SupertypeRule<C>>,
     override val topType: Type = AnyType,
     override val bottomType: Type = NoneType,
 ) : TypeLattice<C> {
-    private val supertypeRelations: List<SupertypeRelation<*, in C>> = supertypeRelations.toList()
-    private val supertypeRule: List<SupertypeRule<in C>> = subtypeRules.toList()
+    private val supertypeRelations: List<SupertypeRelation<*, C>> = supertypeRelations.toList()
+    private val supertypeRule: List<SupertypeRule<C>> = subtypeRules.toList()
     private val supertypes: MutableMap<Type, Set<Type>> = mutableMapOf()
     private val subtypeCache: Cache<Pair<Type, Type>, Boolean> = lraCache(100)
 

--- a/dialector-kt/src/main/kotlin/dev/dialector/semantic/type/lattice/SupertypeRelation.kt
+++ b/dialector-kt/src/main/kotlin/dev/dialector/semantic/type/lattice/SupertypeRelation.kt
@@ -7,8 +7,8 @@ import dev.dialector.semantic.type.TypePredicate
  * Defines a relation between some category of types matching a [TypePredicate] and a set of valid supertypes for all types
  * in that category. Multiple relations may apply to the same type.
  */
-public interface SupertypeRelation<T : Type, C> {
-    public val isValidFor: TypePredicate<T, in C>
+public interface SupertypeRelation<T : Type, in C> {
+    public val isValidFor: TypePredicate<T, C>
     public fun supertypes(type: T, context: C): Sequence<Type>
 }
 
@@ -19,7 +19,7 @@ public fun <T : Type, C> SupertypeRelation<T, C>.evaluate(candidate: Type, conte
 /**
  * Creates a [SupertypeRelation] indicating that the left-hand type is a subtype of all types produced by the function.
  */
-public infix fun <T : Type, C> TypePredicate<T, in C>.hasSupertypes(
+public infix fun <T : Type, C> TypePredicate<T, C>.hasSupertypes(
     supertypeFunction: C.(type: T) -> Iterable<Type>,
 ): SupertypeRelation<T, C> = object : SupertypeRelation<T, C> {
     override val isValidFor = this@hasSupertypes
@@ -29,7 +29,7 @@ public infix fun <T : Type, C> TypePredicate<T, in C>.hasSupertypes(
 /**
  * Creates a [SupertypeRelation] indicating that the left-hand type is a subtype of all of the right-hand types.
  */
-public infix fun <T : Type, C> TypePredicate<T, in C>.hasSupertypes(
+public infix fun <T : Type, C> TypePredicate<T, C>.hasSupertypes(
     explicitSupertypes: Iterable<Type>,
 ): SupertypeRelation<T, C> = object : SupertypeRelation<T, C> {
     override val isValidFor = this@hasSupertypes
@@ -39,13 +39,13 @@ public infix fun <T : Type, C> TypePredicate<T, in C>.hasSupertypes(
 /**
  * Creates a [SupertypeRelation] indicating that the left-hand type is a subtype of all of the right-hand types.
  */
-public fun <T : Type, C> TypePredicate<T, in C>.hasSupertypes(
+public fun <T : Type, C> TypePredicate<T, C>.hasSupertypes(
     vararg explicitSupertypes: Type,
 ): SupertypeRelation<T, C> = this hasSupertypes explicitSupertypes.asIterable()
 
 /**
  * Creates a [SupertypeRelation] indicating that the left-hand type is a subtype of the right-hand type.
  */
-public infix fun <T : Type, C> TypePredicate<T, in C>.hasSupertype(
+public infix fun <T : Type, C> TypePredicate<T, C>.hasSupertype(
     explicitSupertype: Type,
 ): SupertypeRelation<T, C> = this.hasSupertypes(explicitSupertype)

--- a/dialector-kt/src/main/kotlin/dev/dialector/semantic/type/lattice/TypeLattice.kt
+++ b/dialector-kt/src/main/kotlin/dev/dialector/semantic/type/lattice/TypeLattice.kt
@@ -58,12 +58,12 @@ public interface TypeLattice<C> : ExtremumSolver<C> {
     public fun isEquivalent(candidate: Type, other: Type, context: C): Boolean
 
     /**
-     * Returns supertypes defined by [SupertypingRelation]s, does not include implicit supertypes derived from
-     * [SubtypeRule]s
+     * Returns supertypes defined by [SupertypeRelation]s, does not include implicit supertypes derived from
+     * [SupertypeRule]s
      */
     public fun directSupertypes(type: Type, context: C): Set<Type>
 }
 
-public interface SupertypeRule<C> {
+public interface SupertypeRule<in C> {
     public fun check(subtype: Type, supertype: Type, context: C): Boolean
 }

--- a/dialector-kt/src/main/kotlin/dev/dialector/syntax/NodePredicate.kt
+++ b/dialector-kt/src/main/kotlin/dev/dialector/syntax/NodePredicate.kt
@@ -9,15 +9,15 @@ import kotlin.reflect.KClass
 /**
  * A clause that matches against [Node]s.
  */
-public interface NodePredicate<T : Node, C> : TypesafePredicate<T, C>
+public interface NodePredicate<T : Node, in C> : TypesafePredicate<T, C>
 
-public class NodeInstancePredicate<T : Node>(forNode: T) : NodePredicate<T, Any>, InstancePredicate<T, Any>(forNode)
+public class NodeInstancePredicate<T : Node>(forNode: T) : NodePredicate<T, Any>, InstancePredicate<T>(forNode)
 
 public class NodeClassifierPredicate<T : Node>(
     forClass: KClass<T>,
-) : NodePredicate<T, Any>, ClassifierPredicate<T, Any>(forClass)
+) : NodePredicate<T, Any>, ClassifierPredicate<T>(forClass)
 
-public class NodeLogicalPredicate<T : Node, C>(
+public class NodeLogicalPredicate<T : Node, in C>(
     forClass: KClass<T>,
     predicate: C.(T) -> Boolean,
 ) : NodePredicate<T, C>, LogicalPredicate<T, C>(forClass, predicate)

--- a/dialector-kt/src/main/kotlin/dev/dialector/util/TypesafePredicate.kt
+++ b/dialector-kt/src/main/kotlin/dev/dialector/util/TypesafePredicate.kt
@@ -6,7 +6,7 @@ import kotlin.reflect.safeCast
 /**
  * Represents a type-safe constraint that can be used as a basis for conditional rules.
  */
-public interface TypesafePredicate<T : Any, C> {
+public interface TypesafePredicate<T : Any, in C> {
     public val clauseClass: KClass<out T>
     public fun predicate(candidate: T, context: C): Boolean
 
@@ -33,22 +33,22 @@ public fun <T : Any, C, R> TypesafePredicate<T, C>.runIfValid(candidate: Any, co
 /**
  * A specialized [TypesafePredicate] that matches against a specific instance using standard equality.
  */
-public abstract class InstancePredicate<T : Any, C>(public val instance: T) : TypesafePredicate<T, C> {
+public abstract class InstancePredicate<T : Any>(public val instance: T) : TypesafePredicate<T, Any> {
     override val clauseClass: KClass<out T> = instance::class
-    override fun predicate(candidate: T, context: C): Boolean = instance == candidate
+    override fun predicate(candidate: T, context: Any): Boolean = instance == candidate
 }
 
 /**
  * A specialized [TypesafePredicate] that matches against instances of a class (or its subclasses).
  */
-public abstract class ClassifierPredicate<T : Any, C>(override val clauseClass: KClass<T>) : TypesafePredicate<T, C> {
-    override fun predicate(candidate: T, context: C): Boolean = true
+public abstract class ClassifierPredicate<T : Any>(override val clauseClass: KClass<T>) : TypesafePredicate<T, Any> {
+    override fun predicate(candidate: T, context: Any): Boolean = true
 }
 
 /**
  * A generalized [TypesafePredicate] that matches against a predicate function.
  */
-public abstract class LogicalPredicate<T : Any, C>(
+public abstract class LogicalPredicate<T : Any, in C>(
     override val clauseClass: KClass<T>,
     private val predicate: C.(T) -> Boolean,
 ) : TypesafePredicate<T, C> {

--- a/dialector-kt/src/test/kotlin/dev/dialector/util/TypesafePredicateTest.kt
+++ b/dialector-kt/src/test/kotlin/dev/dialector/util/TypesafePredicateTest.kt
@@ -19,7 +19,7 @@ class TypesafePredicateTests {
 
     @Test
     fun instancePredicate() {
-        val predicate = object : InstancePredicate<C, Ctx>(C(1)) {}
+        val predicate = object : InstancePredicate<C>(C(1)) {}
         val context = Ctx("hi")
 
         assertTrue(predicate(C(1), context))
@@ -29,7 +29,7 @@ class TypesafePredicateTests {
 
     @Test
     fun classifierPredicate() {
-        val predicate = object : ClassifierPredicate<B, Ctx>(B::class) {}
+        val predicate = object : ClassifierPredicate<B>(B::class) {}
         val context = Ctx("hi")
 
         assertTrue(predicate(B(), context))


### PR DESCRIPTION
The context type parameter for `TypesafePredicate` is now set to `in C` rather than just `C`. This prevents egregious proliferation of use-site variance declarations