### PR TITLE
Diagnostic context extraction

### DIFF
--- a/dialector-kt/src/main/kotlin/dev/dialector/diagnostic/DiagnosticRule.kt
+++ b/dialector-kt/src/main/kotlin/dev/dialector/diagnostic/DiagnosticRule.kt
@@ -3,23 +3,30 @@ package dev.dialector.diagnostic
 import dev.dialector.syntax.Node
 import dev.dialector.syntax.NodePredicate
 
+public interface DiagnosticSeverity {
+    public object Error : DiagnosticSeverity
+    public object Warning : DiagnosticSeverity
+    public object Info : DiagnosticSeverity
+    public object Hint : DiagnosticSeverity
+}
+
 public interface DiagnosticContext {
     /**
      * Registers a diagnostic for the given node.
      */
-    public fun diagnostic(message: String, node: Node)
+    public fun diagnostic(message: String, node: Node, severity: DiagnosticSeverity = DiagnosticSeverity.Error)
 }
 
 /**
  * A rule that produces diagnostics for nodes matching a [NodePredicate]
  */
-public interface DiagnosticRule<T : Node, C : DiagnosticContext> {
+public interface DiagnosticRule<T : Node, C> {
     public val isValidFor: NodePredicate<T, C>
-    public val diagnostics: C.(node: T) -> Unit
+    public val diagnostics: context(DiagnosticContext) C.(node: T) -> Unit
 
-    public operator fun invoke(node: Node, context: C) {
+    public operator fun invoke(node: Node, context: C, diagnosticContext: DiagnosticContext) {
         @Suppress("UNCHECKED_CAST")
-        if (isValidFor(node, context)) context.diagnostics(node as T)
+        if (isValidFor(node, context)) diagnostics(diagnosticContext, context, node as T)
     }
 }
 
@@ -29,10 +36,10 @@ public interface DiagnosticRule<T : Node, C : DiagnosticContext> {
  * @param T The node type being checked.
  * @param C The [DiagnosticContext] type
  */
-public infix fun <T : Node, C : DiagnosticContext> NodePredicate<T, C>.check(
-    check: C.(node: T) -> Unit,
+public infix fun <T : Node, C> NodePredicate<T, C>.check(
+    check: context(DiagnosticContext) C.(node: T) -> Unit,
 ): DiagnosticRule<T, C> =
     object : DiagnosticRule<T, C> {
         override val isValidFor: NodePredicate<T, C> = this@check
-        override val diagnostics: C.(node: T) -> Unit = check
+        override val diagnostics: context(DiagnosticContext) C.(node: T) -> Unit = check
     }

--- a/dialector-kt/src/test/kotlin/dev/dialector/diagnostic/DiagnosticRuleTest.kt
+++ b/dialector-kt/src/test/kotlin/dev/dialector/diagnostic/DiagnosticRuleTest.kt
@@ -32,7 +32,7 @@ class DiagnosticRuleTest {
 
     class TestContext : DiagnosticContext {
         var lastDiagnostic: Pair<String, Node>? = null
-        override fun diagnostic(message: String, node: Node) {
+        override fun diagnostic(message: String, node: Node, severity: DiagnosticSeverity) {
             lastDiagnostic = message to node
         }
     }
@@ -40,34 +40,34 @@ class DiagnosticRuleTest {
     @Test
     fun testDiagnosticRule() {
         with(TestContext()) {
-            rule1(B(5), this)
+            rule1(B(5), this, this)
             assertNull(lastDiagnostic)
         }
 
         with(TestContext()) {
-            rule1(B(-1), this)
+            rule1(B(-1), this, this)
             val result = assertNotNull(lastDiagnostic)
             assertEquals(bFail, result.first)
         }
 
         with(TestContext()) {
-            rule1(A(), this)
+            rule1(A(), this, this)
             assertNull(lastDiagnostic)
         }
 
         with(TestContext()) {
-            rule2(B(5), this)
+            rule2(B(5), this, this)
             assertNull(lastDiagnostic)
         }
 
         with(TestContext()) {
-            rule2(B(15), this)
+            rule2(B(15), this, this)
             val result = assertNotNull(lastDiagnostic)
             assertEquals(bSubFail, result.first)
         }
 
         with(TestContext()) {
-            rule2(A(), this)
+            rule2(A(), this, this)
             val result = assertNotNull(lastDiagnostic)
             assertEquals(aFail, result.first)
         }


### PR DESCRIPTION
Small changes to diagnostic rules to support separate context.