### PR TITLE
Fix overeager query invalidation, optimize validation, bump gradle version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/inkt/build.gradle.kts
+++ b/inkt/build.gradle.kts
@@ -53,7 +53,6 @@ publishing {
             }
         }
     }
-    repositories.forEach { println((it as MavenArtifactRepository).url)}
     publications {
         register<MavenPublication>("default") {
             from(components["java"])

--- a/inkt/src/main/kotlin/dev/dialector/inkt/next/QueryDslImpl.kt
+++ b/inkt/src/main/kotlin/dev/dialector/inkt/next/QueryDslImpl.kt
@@ -33,9 +33,12 @@ internal class QueryDefinitionDelegate<K : Any, V>(private val value: QueryDefin
     override operator fun getValue(thisRef: Any?, property: KProperty<*>): QueryDefinition<K, V> = value
 }
 
-internal data class QueryDefinitionImpl<K : Any, V>(
+internal class QueryDefinitionImpl<K : Any, V>(
     override val name: String,
     val logic: QueryFunction<K, V>,
 ) : QueryDefinition<K, V> {
+
+    override fun toString(): String = "QueryDefinition($name)"
+
     override fun execute(context: QueryContext, key: K): V = context.logic(key)
 }


### PR DESCRIPTION
Resolves several bugs:
* Queries assigned a value equal to their already-computed value would invalidate their dependencies
* Queries with transitive dependencies whose inputs had _maybe_ changed would never validate (and thus always recompute).
* Added tests for these cases and several others.

Some enhancements:
* Eliminated a lot of dead code around input value verification (likely added to ensure correct behavior in the presence of the above bugs)
* Reduced the `toString` length of various query internals to make debugging easier.