### PR TITLE
Add toDebugString to Node, minor bugfixes for symbol processor

### DIFF
--- a/dialector-kt-processor/src/main/kotlin/dev/dialector/processor/DialectorSymbolProcessor.kt
+++ b/dialector-kt-processor/src/main/kotlin/dev/dialector/processor/DialectorSymbolProcessor.kt
@@ -157,11 +157,6 @@ class DialectorSymbolProcessor(
     }
 }
 
-/*
- *TODO:
- *  Handle inheritance
- */
-
 class Generator(private val resolver: Resolver) {
     private fun KClass<out Any>.getClassDeclaration(): KSClassDeclaration? =
         resolver.getClassDeclarationByName(resolver.getKSNameFromString(this.qualifiedName!!))
@@ -404,7 +399,7 @@ class Generator(private val resolver: Resolver) {
                                         if (ref.type.resolve().isMarkedNullable) {
                                             it.copy(nullable = true)
                                         } else {
-                                          it
+                                            it
                                         }
                                     },
                                 ).build()
@@ -459,8 +454,19 @@ class Generator(private val resolver: Resolver) {
                 .addProperties(model.children.map { generateChild(it) })
                 // Add references
                 .addProperties(model.references.map { generateReference(it) })
+                .addFunction(generateToString(model))
                 // Implement Node
                 .apply { this.generateNodeImplementation(model) }
+                .build()
+
+        /**
+         * Generates a `toString` implementation that delegates to `toDebugString`
+         */
+        fun generateToString(model: NodeModel) =
+            FunSpec.builder("toString")
+                .addModifiers(KModifier.OVERRIDE)
+                .returns(String::class.asTypeName())
+                .addCode("return super<%T>.%N()", model.nodeClass.toClassName(), Node::toDebugString.name)
                 .build()
 
         fun TypeSpec.Builder.generateNodeImplementation(model: NodeModel) {

--- a/dialector-kt-processor/src/main/kotlin/dev/dialector/processor/DialectorSymbolProcessor.kt
+++ b/dialector-kt-processor/src/main/kotlin/dev/dialector/processor/DialectorSymbolProcessor.kt
@@ -349,13 +349,10 @@ class Generator(private val resolver: Resolver) {
 
         fun generateFactory(model: NodeModel): FunSpec? {
             if (options.factory && model.requiresInit()) {
-                val initializerClassName = ClassName(
-                    options.targetPackage,
-                    model.getBuilderClassName(),
-                )
                 val name = model.getDslFunctionName()
                 return FunSpec.builder(name)
                     .apply {
+                        // Add properties
                         addParameters(
                             model.properties.map { prop ->
                                 ParameterSpec.builder(
@@ -371,6 +368,7 @@ class Generator(private val resolver: Resolver) {
                             },
                         )
 
+                        // Add children
                         addParameters(
                             model.children.map {
                                 val resolvedType = it.type.resolve()
@@ -397,7 +395,7 @@ class Generator(private val resolver: Resolver) {
                             },
                         )
 
-                        // References are initialized using the target identifier
+                        // Add references - initialized using the target identifier
                         addParameters(
                             model.references.map { ref ->
                                 ParameterSpec.builder(
@@ -415,7 +413,7 @@ class Generator(private val resolver: Resolver) {
                     }
                     .returns(model.nodeClass.toClassName())
                     .addCode(CodeBlock.builder()
-                        .beginControlFlow("return $name")
+                        .beginControlFlow("return %N", name)
                         .apply {
                             model.properties.forEach { prop ->
                                 val propName = prop.forProperty.simpleName.asString()
@@ -708,7 +706,7 @@ class Generator(private val resolver: Resolver) {
             builder.addFunction(
                 FunSpec.builder("build")
                     .returns(model.nodeClass.toClassName())
-                    .addStatement("return ${model.baseName}Impl(this)")
+                    .addStatement("return %N(this)", model.getImplClassName())
                     .build(),
             )
 

--- a/dialector-kt/src/main/kotlin/dev/dialector/syntax/DModel.kt
+++ b/dialector-kt/src/main/kotlin/dev/dialector/syntax/DModel.kt
@@ -28,7 +28,7 @@ public interface Node {
     public val properties: Map<String, Any?>
 
     /**
-     * Children are other [Node]s that are "owned" by this [Node]. The relat
+     * Children are other [Node]s that are "owned" by this [Node].
      */
     public val children: Map<String, List<Node>>
 
@@ -36,6 +36,13 @@ public interface Node {
      * References point to other [Node]s in the program graph.
      */
     public val references: Map<String, NodeReference<*>?>
+
+    /**
+     * A debug-friendly string representation for this node.
+     *
+     * This is provided as interfaces (used to define `Node` subtypes) cannot override `toString themselves.
+     */
+    public fun toDebugString(): String = "${this::class.simpleName}@${System.identityHashCode(this)}"
 }
 
 public fun interface ReferenceResolver {


### PR DESCRIPTION
Adds a `toDebugString` function to `Node` to allow node implementations to provide better string support than `ClassName@Hash` (though it defaults to that format).

Symbol processor now auto-generates the `toString` method calling `toDebugString`.