### PR TITLE
Add deep copy support for Nodes

### DIFF
--- a/dialector-kt-processor/src/main/kotlin/dev/dialector/processor/DialectorSymbolProcessor.kt
+++ b/dialector-kt-processor/src/main/kotlin/dev/dialector/processor/DialectorSymbolProcessor.kt
@@ -28,6 +28,7 @@ import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
@@ -312,7 +313,24 @@ class Generator(private val resolver: Resolver) {
             }
             builder.addFunction(generateBuilderDsl(model))
             generateFactory(model)?.let { builder.addFunction(it) }
+            builder.addFunction(generateCopyExtension(model))
         }
+
+        fun generateCopyExtension(model: NodeModel): FunSpec =
+            FunSpec.builder("copy")
+                .receiver(model.nodeClass.toClassName())
+                .addAnnotation(
+                    AnnotationSpec.builder(Suppress::class)
+                        .addMember("%S", "UNCHECKED_CAST")
+                        .build()
+                )
+                .returns(model.nodeClass.toClassName())
+                .addStatement(
+                    "return (this as %T).copyAsNode() as %T",
+                    Node::class.asTypeName(),
+                    model.nodeClass.toClassName()
+                )
+                .build()
 
         fun generateBuilderDsl(model: NodeModel): FunSpec {
             val initializerClassName = ClassName(
@@ -455,6 +473,7 @@ class Generator(private val resolver: Resolver) {
                 // Add references
                 .addProperties(model.references.map { generateReference(it) })
                 .addFunction(generateToString(model))
+                .addFunction(generateCopyMethod(model))
                 // Implement Node
                 .apply { this.generateNodeImplementation(model) }
                 .build()
@@ -468,6 +487,87 @@ class Generator(private val resolver: Resolver) {
                 .returns(String::class.asTypeName())
                 .addCode("return super<%T>.%N()", model.nodeClass.toClassName(), Node::toDebugString.name)
                 .build()
+
+        fun generateCopyMethod(model: NodeModel): FunSpec {
+            val builderClassName = ClassName(options.targetPackage, model.getBuilderClassName())
+
+            return FunSpec.builder("copyAsNode")
+                .addModifiers(KModifier.OVERRIDE)
+                .returns(model.nodeClass.toClassName())
+                .addCode(
+                    CodeBlock.builder()
+                        .apply {
+                            if (model.requiresInit()) {
+                                addStatement("val builder = %T()", builderClassName)
+
+                                model.properties.forEach { prop ->
+                                    val propName = prop.forProperty.simpleName.asString()
+                                    addStatement("builder.%N = this.%N", propName, propName)
+                                }
+
+                                model.children.forEach { child ->
+                                    val childName = child.simpleName.asString()
+                                    val resolvedType = child.type.resolve()
+                                    when {
+                                        resolvedType.isAssignableTo(nullableNodeType) -> {
+                                            if (resolvedType.isMarkedNullable) {
+                                                addStatement(
+                                                    "builder.%N = this.%N?.copyAsNode() as? %T",
+                                                    childName,
+                                                    childName,
+                                                    resolvedType.toTypeName()
+                                                )
+                                            }
+                                            else {
+                                                addStatement(
+                                                    "builder.%N = this.%N.copyAsNode() as %T",
+                                                    childName,
+                                                    childName,
+                                                    resolvedType.toTypeName()
+                                                )
+                                            }
+                                        }
+                                        resolvedType.isAssignableTo(nodeListType) -> {
+                                            val elementType = resolvedType.arguments.first().type!!.resolve()
+                                            addStatement(
+                                                "builder.%N += this.%N.map { it.copyAsNode() as %T }",
+                                                childName,
+                                                childName,
+                                                elementType.toTypeName()
+                                            )
+                                        }
+                                    }
+                                }
+
+                                model.references.forEach { ref ->
+                                    val refName = ref.simpleName.asString()
+                                    val isNullable = ref.type.resolve().isMarkedNullable
+                                    if (isNullable) {
+                                        addStatement("builder.%N = this.%N?.targetIdentifier", refName, refName)
+                                    }
+                                    else {
+                                        addStatement("builder.%N = this.%N.targetIdentifier", refName, refName)
+                                    }
+                                }
+
+                                addStatement("val copied = builder.build()")
+                                addStatement(
+                                    "copied.%M().forEach { it.parent = copied}",
+                                    MemberName("dev.dialector.syntax", "getAllChildren", true)
+                                )
+                                addStatement("return copied")
+                            }
+                            else {
+                                addStatement(
+                                    "return %T()",
+                                    ClassName(options.targetPackage, model.getImplClassName())
+                                )
+                            }
+                        }
+                        .build()
+                )
+                .build()
+        }
 
         fun TypeSpec.Builder.generateNodeImplementation(model: NodeModel) {
             // parent

--- a/dialector-kt-processor/src/test/kotlin/dev/dialector/processor/DialectorSymbolProcessorTest.kt
+++ b/dialector-kt-processor/src/test/kotlin/dev/dialector/processor/DialectorSymbolProcessorTest.kt
@@ -1,9 +1,13 @@
 package dev.dialector.processor
 
 import dev.dialector.processor.ast.childNode
+import dev.dialector.processor.ast.copy
 import dev.dialector.processor.ast.simpleNode
+import dev.dialector.syntax.Node
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
 
 /**
  * These tests are designed to validate the generated code, both its API and its functionality.
@@ -82,5 +86,89 @@ class DialectorSymbolProcessorTest {
         assertEquals(node, node.reference.sourceNode)
         assertEquals(SimpleNode::reference, node.reference.relation)
         assertEquals(SimpleNode::optionalReference, node.optionalReference?.relation)
+    }
+
+    @Test
+    fun copyCreatesDeepCopyWithoutParent() {
+        val singleChildValue = childNode()
+        val optionalChildValue = childNode()
+        val pluralFirstChildValue = childNode()
+        val pluralSecondChildValue = childNode()
+        val original = simpleNode {
+            property = "hello"
+            optionalProperty = "provided"
+            singleChild = singleChildValue
+            optionalChild = optionalChildValue
+            pluralChildren += pluralFirstChildValue
+            pluralChildren += pluralSecondChildValue
+            reference = "target.id"
+            optionalReference = "target.otherId"
+        }
+
+        // Copy the node - no cast needed thanks to the generated copy() extension function
+        val copied = original.copy()
+
+        // Verify copied node has no parent
+        assertNull(copied.parent)
+
+        // Verify properties are copied
+        assertEquals(original.property, copied.property)
+        assertEquals(original.optionalProperty, copied.optionalProperty)
+        assertEquals(original.defaultProperty, copied.defaultProperty)
+
+        // Verify children are deep copied (different instances)
+        assertNotSame(original.singleChild, copied.singleChild)
+        assertNotSame(original.optionalChild, copied.optionalChild)
+        assertNotSame(original.pluralChildren[0], copied.pluralChildren[0])
+        assertNotSame(original.pluralChildren[1], copied.pluralChildren[1])
+
+        // Verify copied children have correct parent
+        assertEquals(copied, copied.singleChild.parent)
+        assertEquals(copied, copied.optionalChild?.parent)
+        assertEquals(copied, copied.pluralChildren[0].parent)
+        assertEquals(copied, copied.pluralChildren[1].parent)
+
+        // Verify references point to same target identifiers
+        assertEquals(original.reference.targetIdentifier, copied.reference.targetIdentifier)
+        assertEquals(original.optionalReference?.targetIdentifier, copied.optionalReference?.targetIdentifier)
+
+        // Verify reference source nodes are updated to the copied node
+        assertEquals(copied, copied.reference.sourceNode)
+        assertEquals(copied, copied.optionalReference?.sourceNode)
+
+        // Verify original is unchanged
+        assertEquals(original, original.singleChild.parent)
+    }
+
+    @Test
+    fun copyAsNodeWorksPolymorphically() {
+        val original: Node = simpleNode {
+            property = "test"
+            singleChild = childNode()
+            reference = "ref.id"
+        }
+
+        // Copy via Node.copyAsNode() - this is the internal method, normally users would use
+        // the generated copy() extension function on the concrete type
+        val copied: Node = original.copyAsNode()
+
+        // Verify it's a different instance
+        assertNotSame(original, copied)
+
+        // Verify it's the same type
+        assertEquals(original::class, copied::class)
+
+        // Verify parent is null
+        assertNull(copied.parent)
+    }
+
+    @Test
+    fun copyWorksForSimpleNodeWithoutChildren() {
+        val original = childNode()
+
+        val copied = original.copy()
+
+        assertNotSame(original, copied)
+        assertNull(copied.parent)
     }
 }

--- a/dialector-kt/src/main/kotlin/dev/dialector/syntax/DModel.kt
+++ b/dialector-kt/src/main/kotlin/dev/dialector/syntax/DModel.kt
@@ -38,6 +38,16 @@ public interface Node {
     public val references: Map<String, NodeReference<*>?>
 
     /**
+     *  Used for internal implementation of deep copy. Generated copy() will handle type casting
+     *  This will create a deep copy of the node and all of its descendants without the parent reference.
+     */
+    public fun copyAsNode(): Node = throw UnsupportedOperationException(
+        "copyAsNode() is not implemented for ${this::class.simpleName}. " +
+                "Use @NodeDefinition to generate an implementation"
+    )
+
+
+    /**
      * A debug-friendly string representation for this node.
      *
      * This is provided as interfaces (used to define `Node` subtypes) cannot override `toString themselves.


### PR DESCRIPTION
Adding a deep copy function to generated code (`copyAsNode`) which returns type node
Also adding a copy function (`copy`) which casts the return of `copyAsNode` to the class impl type
Added test as well for functionality